### PR TITLE
Reminders

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -54,5 +54,9 @@ def create_app():
         # Register kanban controller
         from app.controller.kanban_controller import kanban_bp
         app.register_blueprint(kanban_bp)
+
+        # Register reminder controller
+        from app.controller.reminder_controller import reminder_bp
+        app.register_blueprint(reminder_bp)
     
     return app

--- a/api/app/controller/reminder_controller.py
+++ b/api/app/controller/reminder_controller.py
@@ -1,0 +1,108 @@
+from flask import Blueprint, request, jsonify
+from app.model.reminder_model import ReminderModel
+from app.schema.reminder_schema import ReminderSchema
+from app import db
+
+# Define Reminder Blueprint
+reminder_bp = Blueprint('reminder_bp', __name__)
+
+# Initialize Reminder Schema
+reminder_schema = ReminderSchema()
+reminders_schema = ReminderSchema(many=True)
+
+# Endpoint to create a new reminder
+@reminder_bp.route('/reminder', methods=['POST'])
+def create_reminder():
+    """
+    Creates a reminder based on the contents of
+    the request body for the user.
+    """
+    data = request.get_json()
+
+    # Validate incoming request data
+    errors = reminder_schema.validate(data)
+    if errors:
+        return jsonify(errors), 400
+
+    # Create a new reminder instance
+    new_reminder = ReminderModel(
+        user_id=data['user_id'],
+        title=data['title'],
+        description=data.get('description'),
+        remind_at=data['remind_at'],
+        repeat_interval=data.get('repeat_interval'),
+        repeat_until=data.get('repeat_until'),
+        repeat_count=data.get('repeat_count')
+    )
+
+    # Add and commit the reminder to the database
+    db.session.add(new_reminder)
+    db.session.commit()
+
+    # Return the newly created reminder
+    return jsonify(reminder_schema.dump(new_reminder)), 201
+
+
+# Endpoint to retrieve all reminders for a specific user
+@reminder_bp.route('/reminder/user/<int:user_id>', methods=['GET'])
+def get_user_reminders(user_id):
+    """
+    Retrieves all reminders for the user by user_id.
+    """
+    # Query the database for reminders by user_id
+    reminders = ReminderModel.query.filter_by(user_id=user_id).all()
+
+    if not reminders:
+        return jsonify({"message": "No reminders found for this user."}), 404
+
+    # Serialize the list of reminders and return
+    return jsonify(reminders_schema.dump(reminders)), 200
+
+
+# Endpoint to retrieve all reminders
+@reminder_bp.route('/reminder', methods=['GET'])
+def get_all_reminders():
+    """
+    Returns all reminders stored in the database.
+    """
+    # Query the database for all reminders
+    reminders = ReminderModel.query.all()
+
+    # Serialize the list of reminders and return
+    return jsonify(reminders_schema.dump(reminders)), 200
+
+
+# Endpoint to retrieve a reminder by its ID
+@reminder_bp.route('/reminder/<int:id>', methods=['GET'])
+def get_reminder(id):
+    """
+    Retrieves a reminder by its ID.
+    """
+    # Query the database for a reminder by its ID
+    reminder = ReminderModel.query.get(id)
+
+    if reminder is None:
+        return jsonify({"message": "Reminder not found."}), 404
+
+    # Serialize and return the reminder
+    return jsonify(reminder_schema.dump(reminder)), 200
+
+
+# Endpoint to delete a reminder by its ID
+@reminder_bp.route('/reminder/<int:id>', methods=['DELETE'])
+def delete_reminder(id):
+    """
+    Delete a reminder by its ID.
+    """
+    # Query the database for a reminder by its ID
+    reminder = ReminderModel.query.get(id)
+
+    if reminder is None:
+        return jsonify({"message": "Reminder not found."}), 404
+
+    # Delete the reminder and commit the changes
+    db.session.delete(reminder)
+    db.session.commit()
+
+    # Return 204 No Content status
+    return '', 204

--- a/api/app/controller/user_controller.py
+++ b/api/app/controller/user_controller.py
@@ -110,6 +110,27 @@ def delete_user(id):
     # Return 204 No Content
     return '', 204
 
+# Set Timezone endpoint
+@user_bp.route('/user/<int:id>/timezone', methods=['PUT'])
+def set_user_timezone(id):
+    user = User.query.get(id)
+    if user is None:
+        return jsonify({'message': 'User not found'}), 404
+    
+    data = request.get_json()
+    
+    # Check if timezone is provided in the request body
+    if 'timezone' not in data:
+        return jsonify({'message': 'Timezone is required'}), 400
+
+    timezone = data['timezone']
+
+    # Update user's timezone if valid
+    user.timezone = timezone
+    db.session.commit()
+
+    return jsonify(user_schema.dump(user))
+
 # Search endpoint
 @user_bp.route('/user/search', methods=['POST'])
 def search_users():

--- a/api/app/model/reminder_model.py
+++ b/api/app/model/reminder_model.py
@@ -1,0 +1,16 @@
+from app import db
+from datetime import datetime
+
+class ReminderModel(db.Model):
+    __tablename__ = 'reminder'
+
+    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.BigInteger, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False)
+    title = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    remind_at = db.Column(db.DateTime, nullable=False)
+    repeat_interval = db.Column(db.String(50), nullable=True)
+    repeat_until = db.Column(db.DateTime, nullable=True)  # NULL means no end
+    repeat_count = db.Column(db.Integer, nullable=True)  # NULL means indefinite
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/app/model/user_model.py
+++ b/api/app/model/user_model.py
@@ -6,5 +6,6 @@ class User(db.Model):
     id = db.Column(db.BigInteger, primary_key=True, autoincrement=False)
     tokens = db.Column(db.Integer, nullable=False)
     stime = db.Column(db.BigInteger, nullable=False)
+    timezone = db.Column(db.String(100), nullable=False, default='UTC')
     hex = db.Column(db.String(7), nullable=True)
     trivia = db.Column(db.Integer, nullable=True)

--- a/api/app/schema/reminder_schema.py
+++ b/api/app/schema/reminder_schema.py
@@ -1,0 +1,27 @@
+from marshmallow import Schema, fields, validate, ValidationError
+import re
+
+# Custom validator for combinations of mtwhfsu
+def validate_repeat_interval(value):
+    # Allow standard intervals
+    standard_intervals = ['daily', 'weekly', 'monthly', 'yearly']
+    if value in standard_intervals:
+        return True
+    
+    # Regex pattern to match any combination of mtwhfsu
+    if re.fullmatch(r'[mtwhfsu]+', value):
+        return True
+    
+    raise ValidationError(f"Invalid repeat_interval: {value}. Must be a valid combination of 'mtwhfsu' or a standard interval (daily, weekly, monthly, yearly).")
+
+class ReminderSchema(Schema):
+    id = fields.Int(dump_only=True)
+    user_id = fields.Int(required=True)
+    title = fields.Str(required=True, validate=validate.Length(max=255))
+    description = fields.Str()
+    remind_at = fields.DateTime(required=True, format="%Y-%m-%dT%H:%M:%S")
+    repeat_interval = fields.Str(validate=validate_repeat_interval)  # Custom validator here
+    repeat_until = fields.DateTime(format="%Y-%m-%dT%H:%M:%S")
+    repeat_count = fields.Int(validate=validate.Range(min=0))
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)

--- a/api/app/schema/user_schema.py
+++ b/api/app/schema/user_schema.py
@@ -4,5 +4,6 @@ class UserSchema(Schema):
     id = fields.Int(required=True)
     tokens = fields.Int(required=True)
     stime = fields.Int(required=True)
+    timezone = fields.Str(required=False)
     hex = fields.Str(required=False)
     trivia = fields.Int(required=False)

--- a/api/tools/utils.py
+++ b/api/tools/utils.py
@@ -1,10 +1,11 @@
-from datetime import datetime, timezone
+import pytz
+from datetime import datetime
 
 class DateTimeUtils():
 
     @staticmethod
     def get_utc_date_now():
-        now_utc = datetime.now(timezone.utc)
+        now_utc = datetime.now(pytz.utc)
         d = now_utc.day
         mth = now_utc.month
         yr = now_utc.year
@@ -13,7 +14,7 @@ class DateTimeUtils():
     
     @staticmethod
     def get_utc_month_year_now():
-        now_utc = datetime.now(timezone.utc)
+        now_utc = datetime.now(pytz.utc)
         mth = now_utc.month
         yr = now_utc.year
         return mth, yr

--- a/bot/apps/info/timezone.py
+++ b/bot/apps/info/timezone.py
@@ -1,0 +1,38 @@
+"""
+timezone.py
+author: narlock
+
+Interface to change timezone information for a user.
+"""
+
+import cfg
+import discord
+import pytz
+
+from datetime import datetime
+from client.alder.interface.user_client import UserClient
+
+class TimeZoneApp():
+    def set_timezone(self, interaction: discord.Interaction, timezone: str):
+        """
+        Sets the user's timezone.
+        """
+
+        # Validate the timezone string
+        try:
+            pytz.timezone(timezone)
+        except:
+            message = f'The timezone {timezone} is not a valid timezone.\nPlease try again.\n\nExample: America/New_York'
+            return cfg.ErrorEmbed.message(message)
+        
+        # The timezone string is valid. Set it
+        try:
+            UserClient.set_timezone(interaction.user.id, timezone)
+            embed = discord.Embed(title=f'Timezone Changed', color=0xffa500)
+            embed.add_field(name='\u200b', value=f'Your timezone has been updated to {timezone}.', inline=False)
+            embed.add_field(name='\u200b', value=cfg.EMBED_FOOTER_STRING, inline=False)
+            return embed
+        except:
+            message = f'An unexpected error occurred'
+            return cfg.ErrorEmbed.message(message)
+        

--- a/bot/apps/info/timezone.py
+++ b/bot/apps/info/timezone.py
@@ -13,10 +13,12 @@ from datetime import datetime
 from client.alder.interface.user_client import UserClient
 
 class TimeZoneApp():
-    def set_timezone(self, interaction: discord.Interaction, timezone: str):
+    @staticmethod
+    def set_timezone(interaction: discord.Interaction, timezone: str):
         """
         Sets the user's timezone.
         """
+        UserClient.create_user_if_dne(interaction.user.id)
 
         # Validate the timezone string
         try:
@@ -27,7 +29,11 @@ class TimeZoneApp():
         
         # The timezone string is valid. Set it
         try:
-            UserClient.set_timezone(interaction.user.id, timezone)
+            response = UserClient.set_timezone(interaction.user.id, timezone)
+            
+            if response is None:
+                raise Exception
+            
             embed = discord.Embed(title=f'Timezone Changed', color=0xffa500)
             embed.add_field(name='\u200b', value=f'Your timezone has been updated to {timezone}.', inline=False)
             embed.add_field(name='\u200b', value=cfg.EMBED_FOOTER_STRING, inline=False)

--- a/bot/apps/productivity/reminder.py
+++ b/bot/apps/productivity/reminder.py
@@ -1,0 +1,7 @@
+"""
+reminder.py
+author: narlock
+
+Interface for sending reminders to users
+"""
+

--- a/bot/client/alder/interface/reminder_client.py
+++ b/bot/client/alder/interface/reminder_client.py
@@ -1,0 +1,123 @@
+"""
+reminder_client.py
+author: narlock
+
+Alder interface for making HTTP requests to the
+reminder resource on the Alder API
+"""
+
+import json
+
+from client.alder.alder_api_client import AlderAPIClient
+
+class ReminderClient():
+    """
+    Alder interface for making HTTP requests to the
+    reminder resource on the Alder API.
+    """
+
+    @staticmethod
+    def get_all_reminders():
+        """
+        Retrieves all reminders that are in the database
+        """
+        response = AlderAPIClient.get('/reminder')
+        print(response)
+
+        # If the response is None, empty, or not successful, return None
+        if not response or response.status_code != 200:
+            return None
+        
+        return json.loads(response.text)
+    
+    @staticmethod
+    def get_user_reminders(user_id: int):
+        """
+        Retrieve all reminders for the user denoted by their
+        user_id.
+        """
+        response = AlderAPIClient.get(f'/reminder/user/{user_id}')
+
+        # If the response is None, empty or not successful, return None
+        if not response or response.status_code != 200:
+            return None
+        
+        return json.loads(response.text)
+    
+    @staticmethod
+    def get_reminder_by_id(id: int):
+        """
+        Retrieve a reminder by its unique identifier.
+        """
+        response = AlderAPIClient.get(f'/reminder/{id}')
+
+        # If the response is None or not successful, return None
+        if not response or response.status_code != 200:
+            return None
+        
+        return json.loads(response.text)
+    
+    @staticmethod
+    def create_reminder(user_id: int, title: str, remind_at, repeat_interval = None, repeat_until = None, repeat_count = None):
+        """
+        Creates a reminder for the user_id called title. Will be reminded at
+        remind_at parameter. The reminder will repeat if provided repeat
+        criteria.
+
+        Repeat Interval can be 'daily', 'weekly', 'monthly', 'yearly', and a combination of 'mtwhfsu'
+        """
+        # Create a JSON payload with the provided parameters
+        request_body = {
+            'user_id': user_id,
+            'title': title,
+            'remind_at': remind_at,
+            'repeat_interval': repeat_interval,
+            'repeat_until': repeat_until,
+            'repeat_count': repeat_count
+        }
+
+        # Remove any keys with None values to avoid sending them in the request body
+        request_body = {k: v for k, v in request_body.items() if v is not None}
+
+        # Send the POST request to the '/reminder' endpoint
+        response = AlderAPIClient.post('/reminder', request_body)
+
+        # If the response is not successful, return None
+        if not response or response.status_code != 201:
+            return None
+
+        # Return the response as JSON
+        return json.loads(response.text)
+    
+    @staticmethod
+    def delete_reminder_by_id(id: int):
+        """
+        Deletes a reminder by its id.
+        """
+        return AlderAPIClient.delete(f'/reminder/{id}')
+
+    @staticmethod
+    def update_reminder_date(id: int, remind_date: str):
+        """
+        Updates the remind_at date for the reminder with the given id.
+        The time component of the remind_at field will remain unchanged.
+        
+        :param id: The unique identifier of the reminder.
+        :param remind_date: The new date string (YYYY-MM-DD) to set for the remind_at field.
+        """
+        # Create the request body with the new remind_at date
+        request_body = {
+            'remind_at': remind_date  # Only update the date part, leave time unchanged
+        }
+
+        # Send the PUT request to the '/reminder/<id>/date' endpoint
+        response = AlderAPIClient.put(f'/reminder/{id}/date', request_body)
+
+        print(response)
+
+        # If the response is not successful, return None
+        if not response or response.status_code != 200:
+            return None
+
+        # Return the response as JSON
+        return json.loads(response.text)

--- a/bot/client/alder/interface/user_client.py
+++ b/bot/client/alder/interface/user_client.py
@@ -103,6 +103,10 @@ class UserClient():
 
         # Perform set timezone operation
         response = AlderAPIClient.put(f"/user/{id}/timezone", request_body)
+
+        if not response or response.status_code == 404:
+            return None
+        
         return json.loads(response.text)
     
     # =====================

--- a/bot/client/alder/interface/user_client.py
+++ b/bot/client/alder/interface/user_client.py
@@ -89,6 +89,22 @@ class UserClient():
         """
         return AlderAPIClient.delete(f'/user/{id}')
     
+    @staticmethod
+    def set_timezone(id: str, timezone: str):
+        """
+        Calls the set timezone endpoint which puts the
+        value of {timezone} parameter in the user with
+        {id} row.
+        """
+        # Construct request body
+        request_body = {
+            "timezone": timezone
+        }
+
+        # Perform set timezone operation
+        response = AlderAPIClient.put(f"/user/{id}/timezone", request_body)
+        return json.loads(response.text)
+    
     # =====================
     # HELPER FUNCTIONS
     # =====================

--- a/bot/main.py
+++ b/bot/main.py
@@ -329,6 +329,16 @@ async def resetmonth(ctx: commands.Context):
         await ctx.send("LOL! :rofl:")
         Logger.warn(f"Reset Month attempt failure. User {ctx.author.name} has insufficient permissions.")
 
+@bot.command(name='dmtest')
+async def dmtest(ctx: commands.Context):
+    """
+    test
+    """
+    try:
+        await ctx.author.send("Hello")
+    except discord.Forbidden:
+        await ctx.send('forbidden')
+
 ##########################################
 ##########################################
 # Voice Events
@@ -467,6 +477,17 @@ async def top(interaction: discord.Interaction, board: str = None):
 
     # Send the embed in response to the interaction
     await interaction.response.send_message(embed=embed)
+
+@bot.tree.command(name='timezone', description='Change your timezone')
+async def timezone(interaction: discord.Interaction, timezone: str):
+    """
+    /timezone {timezone_string}
+
+    Sets the timezone of the user to the {timezone_string} parameter.
+    Currently, timezone is only used for the reminders application.
+    """
+    embed = timezone_app.set_timezone(interaction, timezone)
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 # ##########################################
 # ##########################################

--- a/docs/install.markdown
+++ b/docs/install.markdown
@@ -23,6 +23,7 @@ The official bot that runs this source code is found on the [narlock Discord ser
 - [PyMySQL](https://pypi.org/project/PyMySQL/)
 - [Flask-SQLAlchemy](https://pypi.org/project/Flask-SQLAlchemy/)
 - [marshmallow-sqlalchemy](https://pypi.org/project/marshmallow-sqlalchemy/)
+- [pytz](https://pypi.org/project/pytz/)
 
 ## Python
 This Discord bot is programmed using the [Python](https://www.python.org/) programming language. This means that if you wish to self host the bot for yourself or contribute to the bot's functionality, you will need to install Python.

--- a/setupdb.sql
+++ b/setupdb.sql
@@ -9,6 +9,7 @@ CREATE TABLE user(
     id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
     tokens INT UNSIGNED NOT NULL,
     stime BIGINT UNSIGNED NOT NULL,
+    timezone VARCHAR(100) NOT NULL DEFAULT 'UTC',
     hex VARCHAR(7),
     trivia INT UNSIGNED
 );
@@ -110,6 +111,21 @@ CREATE TABLE kanban (
     tag_name VARCHAR(50),
     velocity INT,
     FOREIGN KEY (user_id) REFERENCES user(id)
+);
+
+DROP TABLE IF EXISTS `reminder`;
+CREATE TABLE reminder (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT UNSIGNED NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    remind_at DATETIME NOT NULL,
+    repeat_interval VARCHAR(50), -- e.g., 'daily', 'weekly', 'monthly', 'yearly', or a custom like: 'every_other_day', 'every_monday', 'every_tuesday', 'every_wednesday', 'every_thursday', 'every_friday', 'every_saturday', 'every_sunday', or combination of 'mtwhfsu'
+    repeat_until DATETIME, -- The date until which the reminder should repeat, NULL means indefinitely
+    repeat_count INT UNSIGNED, -- The number of times to repeat, NULL for indefinite or repeat until a specific date
+    created_at DATETIME,
+    updated_at DATETIME,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );
 
 -- Insert sample data


### PR DESCRIPTION
Switches to use `pytz` for some time zone related things... Going to be used for when a user creates a reminder. It can use their timezone to create a reminder for their specified time zone. 

Currently, the implementation assumes UTC time zone is used. This is so time is consistent. In the future, we will use the user's `timezone` value and then convert their time zone to UTC.